### PR TITLE
channel keep alive span

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,33 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.2.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-trace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+        </dependency>
+    </dependencies>
 
     <licenses>
         <license>

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/RemotingOpenTelemetryComputerListener.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/RemotingOpenTelemetryComputerListener.java
@@ -3,8 +3,16 @@ package io.jenkins.plugins.remotingopentelemetry;
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.model.TaskListener;
+import hudson.remoting.Channel;
+import hudson.remoting.VirtualChannel;
 import hudson.slaves.ComputerListener;
 import io.jenkins.plugins.remotingopentelemetry.commands.SyncMonitoringEngineCommand;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import jenkins.model.Jenkins.MasterComputer;
 
 import java.io.IOException;
@@ -19,6 +27,19 @@ public final class RemotingOpenTelemetryComputerListener extends ComputerListene
     @Override
     public final void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {
         if (c instanceof MasterComputer) return;
-        c.getChannel().call(new SyncMonitoringEngineCommand());
+        VirtualChannel vc = c.getChannel();
+        vc.call(new SyncMonitoringEngineCommand());
+        if (vc instanceof Channel) {
+            Channel ch = (Channel) vc;
+
+            // Send JAR files to the agent in advance to run the MonitoringEngine even in offline.
+            // TODO: Enable to auto-detect the dependent JAR files.
+            ch.preloadJar(getClass().getClassLoader(), OpenTelemetrySdk.class);      // opentelemetry-sdk-<version>.jar
+            ch.preloadJar(getClass().getClassLoader(), CompletableResultCode.class); // opentelemetry-sdk-commmon-<version>.jar
+            ch.preloadJar(getClass().getClassLoader(), SdkTracerProvider.class);     // opentelemetry-sdk-trace-<version>.jar
+            ch.preloadJar(getClass().getClassLoader(), OpenTelemetry.class);         // opentelemetry-api-<version>.jar
+            ch.preloadJar(getClass().getClassLoader(), LoggingSpanExporter.class);   // opentelemetry-exporter-logging-<version>.jar
+            ch.preloadJar(getClass().getClassLoader(), Scope.class);                 // opentelemetry-context-<version>.jar
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/OpenTelemetryProxy.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/OpenTelemetryProxy.java
@@ -1,0 +1,38 @@
+package io.jenkins.plugins.remotingopentelemetry.engine;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+public class OpenTelemetryProxy {
+    private static final String INSTRUMENTATION_NAME = "jenkins remoting";
+    private static Tracer tracer;
+
+    public static void build() {
+         build(new LoggingSpanExporter());
+    }
+
+    public static void build(SpanExporter exporter) {
+        SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+
+        OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
+                .setTracerProvider(sdkTracerProvider)
+                .build();
+
+        tracer = openTelemetry.getTracer(INSTRUMENTATION_NAME);
+    }
+
+    public static Tracer getTracer() {
+        return tracer;
+    }
+
+    public static void clean() {
+        tracer = null;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RemoteEngineListener.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RemoteEngineListener.java
@@ -1,0 +1,46 @@
+package io.jenkins.plugins.remotingopentelemetry.engine.listener;
+
+import hudson.remoting.EngineListener;
+import io.jenkins.plugins.remotingopentelemetry.engine.span.ChannelKeepAliveSpan;
+
+/**
+ * Handles the events from {@link hudson.remoting.Engine}
+ */
+public class RemoteEngineListener implements EngineListener {
+    @Override
+    public void status(String s) {
+        switch (s) {
+            case "Connected":
+                new ChannelKeepAliveSpan().start();
+                break;
+            case "Terminated":
+                ChannelKeepAliveSpan span = ChannelKeepAliveSpan.current();
+                if (span != null) {
+                    span.end();
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    public void status(String s, Throwable throwable) {
+
+    }
+
+    @Override
+    public void error(Throwable throwable) {
+
+    }
+
+    @Override
+    public void onDisconnect() {
+
+    }
+
+    @Override
+    public void onReconnect() {
+
+    }
+}

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RootListener.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RootListener.java
@@ -1,0 +1,42 @@
+package io.jenkins.plugins.remotingopentelemetry.engine.listener;
+
+import hudson.remoting.Engine;
+import io.jenkins.plugins.remotingopentelemetry.engine.span.ChannelKeepAliveSpan;
+import io.jenkins.plugins.remotingopentelemetry.engine.MonitoringEngine;
+
+import javax.annotation.Nullable;
+import java.util.EventListener;
+
+/**
+ * Handles the events from {@link MonitoringEngine} and setups child event listeners.
+ */
+public class RootListener implements EventListener {
+    private final RemoteEngineListener remoteEngineListener = new RemoteEngineListener();
+
+    @Nullable
+    private Engine remoteEngine = null;
+
+    public void preStartMonitoringEngine() {
+        remoteEngine = Engine.current();
+        if (remoteEngine != null) {
+            remoteEngine.addListener(remoteEngineListener);
+
+            // Currently, we have no way to catch first connection established event,
+            // so instead, we start ChannelKeepAliveSpan at this point.
+            new ChannelKeepAliveSpan().start();
+        }
+    }
+
+    public void onTerminateMonitoringEngine() {
+        onTerminateMonitoringEngine(null);
+    }
+    public void onTerminateMonitoringEngine(Exception e) {
+        if (remoteEngine != null) {
+            remoteEngine.removeListener(remoteEngineListener);
+        }
+        ChannelKeepAliveSpan channelKeepAliveSpan = ChannelKeepAliveSpan.current();
+        if (channelKeepAliveSpan != null) {
+            channelKeepAliveSpan.end();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/span/ChannelKeepAliveSpan.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/span/ChannelKeepAliveSpan.java
@@ -1,0 +1,42 @@
+package io.jenkins.plugins.remotingopentelemetry.engine.span;
+
+import io.jenkins.plugins.remotingopentelemetry.engine.OpenTelemetryProxy;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+
+import javax.annotation.Nullable;
+
+public class ChannelKeepAliveSpan implements MonitoringSpan {
+    @Nullable
+    private static ChannelKeepAliveSpan currentSpan = null;
+    public static final String SPAN_NAME = "channel keep alive";
+    @Nullable
+    public static synchronized ChannelKeepAliveSpan current() {
+        return currentSpan;
+    }
+    private static synchronized void setCurrent(ChannelKeepAliveSpan span) {
+        currentSpan = span;
+    }
+
+    private final Tracer tracer;
+    private Span span;
+
+    public ChannelKeepAliveSpan() {
+        tracer = OpenTelemetryProxy.getTracer();
+    }
+
+    public void start() {
+        this.span = tracer.spanBuilder(SPAN_NAME).startSpan();
+        if (currentSpan != null) {
+            currentSpan.end();
+        }
+        setCurrent(this);
+    }
+
+    public void end() {
+        if (span != null) {
+            span.end();
+        }
+        setCurrent(null);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/span/MonitoringSpan.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/span/MonitoringSpan.java
@@ -1,0 +1,5 @@
+package io.jenkins.plugins.remotingopentelemetry.engine.span;
+
+public interface MonitoringSpan {
+    void end();
+}

--- a/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/MonitoringEngineTest.java
+++ b/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/MonitoringEngineTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.remotingopentelemetry.engine;
 
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.Objects;
@@ -12,6 +13,8 @@ public class MonitoringEngineTest {
         assert MonitoringEngine.isRunning();
         MonitoringEngine.terminate();
         assert !MonitoringEngine.isRunning();
+        MonitoringEngine.launch();
+        assert MonitoringEngine.isRunning();
     }
 
     @Test
@@ -25,5 +28,10 @@ public class MonitoringEngineTest {
                 .filter(t -> Objects.equals(t.getClass().getCanonicalName(), MonitoringEngine.class.getCanonicalName()))
                 .toArray(Thread[]::new);
         assert monitoringThreads.length == 1;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        MonitoringEngine.terminate();
     }
 }

--- a/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RemoteEngineListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RemoteEngineListenerTest.java
@@ -1,0 +1,43 @@
+package io.jenkins.plugins.remotingopentelemetry.engine.listener;
+
+import io.jenkins.plugins.remotingopentelemetry.engine.OpenTelemetryProxy;
+import io.jenkins.plugins.remotingopentelemetry.engine.span.ChannelKeepAliveSpan;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RemoteEngineListenerTest {
+    InMemorySpanExporter exporter;
+
+    @Before
+    public void setup() throws Exception {
+        exporter = InMemorySpanExporter.create();
+        OpenTelemetryProxy.build(exporter);
+    }
+
+    @Test
+    public void testStatusConnected() throws Exception {
+        assert ChannelKeepAliveSpan.current() == null;
+        RemoteEngineListener listener = new RemoteEngineListener();
+        listener.status("Connected");
+        assert ChannelKeepAliveSpan.current() != null;
+    }
+
+    @Test
+    public void testStatusTerminated() throws Exception {
+        RemoteEngineListener listener = new RemoteEngineListener();
+        listener.status("Connected");
+        assert ChannelKeepAliveSpan.current() != null;
+        listener.status("Terminated");
+        assert ChannelKeepAliveSpan.current() == null;
+        assert exporter.getFinishedSpanItems().size() == 1;
+        assert exporter.getFinishedSpanItems().get(0).getName().equals(ChannelKeepAliveSpan.SPAN_NAME);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        OpenTelemetryProxy.clean();
+        exporter.reset();
+    }
+}

--- a/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RootListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RootListenerTest.java
@@ -1,0 +1,33 @@
+package io.jenkins.plugins.remotingopentelemetry.engine.listener;
+
+import io.jenkins.plugins.remotingopentelemetry.engine.OpenTelemetryProxy;
+import io.jenkins.plugins.remotingopentelemetry.engine.span.ChannelKeepAliveSpan;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RootListenerTest {
+    RootListener rootListener;
+
+    @Before
+    public void setup() throws Exception {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        OpenTelemetryProxy.build(exporter);
+        rootListener = new RootListener();
+    }
+
+    @Test
+    public void testTerminatedMonitoringEngine() {
+        new ChannelKeepAliveSpan().start();
+        assert ChannelKeepAliveSpan.current() != null;
+        rootListener.onTerminateMonitoringEngine();
+        assert ChannelKeepAliveSpan.current() == null;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        rootListener.onTerminateMonitoringEngine();
+        OpenTelemetryProxy.clean();
+    }
+}

--- a/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/span/ChannelKeepAliveSpanTest.java
+++ b/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/span/ChannelKeepAliveSpanTest.java
@@ -1,0 +1,40 @@
+package io.jenkins.plugins.remotingopentelemetry.engine.span;
+
+import io.jenkins.plugins.remotingopentelemetry.engine.OpenTelemetryProxy;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ChannelKeepAliveSpanTest {
+    @Before
+    public void setup() throws Exception {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        OpenTelemetryProxy.build(exporter);
+        ChannelKeepAliveSpan span = ChannelKeepAliveSpan.current();
+        if (span != null) {
+            span.end();
+        }
+    }
+
+    @Test
+    public void testStart() throws Exception {
+        assert ChannelKeepAliveSpan.current() == null;
+        new ChannelKeepAliveSpan().start();
+        assert ChannelKeepAliveSpan.current() != null;
+        new ChannelKeepAliveSpan().end();
+    }
+
+    @Test
+    public void testEnd() throws Exception {
+        new ChannelKeepAliveSpan().start();
+        assert ChannelKeepAliveSpan.current() != null;
+        new ChannelKeepAliveSpan().end();
+        assert ChannelKeepAliveSpan.current() == null;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        OpenTelemetryProxy.clean();
+    }
+}

--- a/src/test/java/io/opentelemetry/sdk/testing/exporter/InMemorySpanExporter.java
+++ b/src/test/java/io/opentelemetry/sdk/testing/exporter/InMemorySpanExporter.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.exporter;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link SpanExporter} implementation that can be used to test OpenTelemetry integration.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // class MyClassTest {
+ * //   private final Tracer tracer = new TracerSdk();
+ * //   private final InMemorySpanExporter testExporter = InMemorySpanExporter.create();
+ * //
+ * //   @Before
+ * //   public void setup() {
+ * //     tracer.addSpanProcessor(SimpleSampledSpansProcessor.builder(testExporter).build());
+ * //   }
+ * //
+ * //   @Test
+ * //   public void getFinishedSpanData() {
+ * //     tracer.spanBuilder("span").startSpan().end();
+ * //
+ * //     List<Span> spanItems = exporter.getFinishedSpanItems();
+ * //     assertThat(spanItems).isNotNull();
+ * //     assertThat(spanItems.size()).isEqualTo(1);
+ * //     assertThat(spanItems.get(0).getName()).isEqualTo("span");
+ * //   }
+ * // }
+ * }</pre>
+ */
+public final class InMemorySpanExporter implements SpanExporter {
+    private final List<SpanData> finishedSpanItems = new ArrayList<>();
+    private boolean isStopped = false;
+
+    /**
+     * Returns a new instance of the {@code InMemorySpanExporter}.
+     *
+     * @return a new instance of the {@code InMemorySpanExporter}.
+     */
+    public static InMemorySpanExporter create() {
+        return new InMemorySpanExporter();
+    }
+
+    /**
+     * Returns a {@code List} of the finished {@code Span}s, represented by {@code SpanData}.
+     *
+     * @return a {@code List} of the finished {@code Span}s.
+     */
+    public List<SpanData> getFinishedSpanItems() {
+        synchronized (this) {
+            return Collections.unmodifiableList(new ArrayList<>(finishedSpanItems));
+        }
+    }
+
+    /**
+     * Clears the internal {@code List} of finished {@code Span}s.
+     *
+     * <p>Does not reset the state of this exporter if already shutdown.
+     */
+    public void reset() {
+        synchronized (this) {
+            finishedSpanItems.clear();
+        }
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> spans) {
+        synchronized (this) {
+            if (isStopped) {
+                return CompletableResultCode.ofFailure();
+            }
+            finishedSpanItems.addAll(spans);
+        }
+        return CompletableResultCode.ofSuccess();
+    }
+
+    /**
+     * The InMemory exporter does not batch spans, so this method will immediately return with
+     * success.
+     *
+     * @return always Success
+     */
+    @Override
+    public CompletableResultCode flush() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    /**
+     * Clears the internal {@code List} of finished {@code SpanData}s.
+     *
+     * <p>Any subsequent call to export() function on this SpanExporter, will return {@code
+     * CompletableResultCode.ofFailure()}
+     */
+    @Override
+    public CompletableResultCode shutdown() {
+        synchronized (this) {
+            finishedSpanItems.clear();
+            isStopped = true;
+        }
+        return CompletableResultCode.ofSuccess();
+    }
+
+    private InMemorySpanExporter() {}
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

close #5 

## What I did

- Create a listener tree system
  - Every listener to obtain telemetry data will be generated from `RootListener` and its child listeners.
  - Monitoring Engine tells `RootListener` a fundamental timing and objects
  - RootListener setups child listeners, e.g. EngineListener.
- Create a custom span class (ChannelKeepAliveSpan)
- Create OpenTelemeryProxy
  - Enables fetching the tracer object from anywhere.
- Tests

## I'm leaving the following related issues

#31 

## Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] All follow-ups are documented as issues and-or TODO comments
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
- [ ] Please update user documentation if needed
- [ ] Please update developer documentation if needed
