### PR TITLE
Enable to provide telemetry data to OpenTelemetry Collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ log/
 target/
 
 work/
+*.jar

--- a/example/README.adoc
+++ b/example/README.adoc
@@ -1,0 +1,55 @@
+== Setup with development environment
+
+=== 0. Setup Docker and Docker compose
+
+- https://docs.docker.com/get-docker/
+- https://docs.docker.com/compose/install/
+
+=== 1. Setup OpenTelemetry Collector, Jaeger and Zipkin
+
+....
+$ git clone https://github.com/jenkinsci/remoting-opentelemetry-plugin.git
+$ cd example
+$ docker-compose up
+....
+
+=== 2. Setup development Jenkins server
+
+At the project root,
+
+....
+mvn hpi:run
+....
+
+==== Configure this plugin
+
+Access: http://localhost:8080/jenkins/configureTools/
+(Global Tool Configuration page)
+
+In the "Remoting OpenTelemetry Plugin" section, set "Endpoint" to `http://localhost:55680`
+
+This value is the OpenTelemetry Collector endpoint used on the *agent* side.
+
+=== 3. Setup Jenkins agent
+
+. Create a new node with Jenkins server UI
+** Use JNLP to connect agent. i.e., Set "Launch Method" to "Launch agent by connecting it to the master"
+** Set "Name" and "Remote root directory" as you like, and we will use the values to launch agents.
+. Run and connect new node
+** Use helper function
+
+ ./example/launch_agent.sh -w /path/to/work/dir -n node-name
+
+=== 4. Create Span
+
+As we have only Channel Keep-Alive span now, we need to disconnect agents to produce spans.
+
+Try disconnecting agents from the agent detail page.
+
+=== 5. Open Jaeger / Zipkin UI
+
+Jaeger: http://localhost:16686/
+
+Zipkin: http://localhost:9411/
+
+Channel KeepAlive span will appear.

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: "3"
+services:
+    jaeger:
+        image: jaegertracing/all-in-one:1.22
+        expose:
+            - 14250
+        ports:
+            - 16686:16686
+
+    zipkin:
+        image: openzipkin/zipkin
+        ports:
+            - 9411:9411
+
+    otel_collector:
+        image: otel/opentelemetry-collector
+        command: ["--config=/otel-collector-config.yaml"]
+        ports:
+            - 55680:55680
+        volumes:
+            - ./otel-collector/otel-collector-config.yaml:/otel-collector-config.yaml
+

--- a/example/launch_agent.sh
+++ b/example/launch_agent.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+help()
+{
+  echo "Usage: $0 -w workdir -n node-name"
+  exit 1
+}
+
+JENKINS_ROOT="${JENKINS_ROOT:-http://localhost:8080/jenkins}"
+
+while getopts w:n: opt
+do
+  case "$opt" in
+    w ) WORK_DIR="$OPTARG" ;;
+    n ) NODE_NAME="$OPTARG" ;;
+    ? ) help ;;
+  esac
+done
+
+if [ -z "$WORK_DIR" ] || [ -z "$NODE_NAME" ]
+then
+  help
+fi
+
+curl $JENKINS_ROOT/jnlpJars/agent.jar -o agent.jar
+java \
+  -Djava.awt.headless=true -jar agent.jar -jnlpUrl $JENKINS_ROOT/computer/$NODE_NAME/slave-agent.jnlp \
+  -workDir $WORK_DIR

--- a/example/otel-collector/otel-collector-config.yaml
+++ b/example/otel-collector/otel-collector-config.yaml
@@ -1,0 +1,32 @@
+receivers:
+    otlp:
+        protocols:
+            grpc:
+
+exporters:
+    jaeger:
+        endpoint: jaeger:14250
+        insecure: true
+    zipkin:
+        endpoint: http://zipkin:9411/api/v2/spans
+        insecure: true
+
+processors:
+    batch:
+
+extensions:
+    health_check:
+    pprof:
+        endpoint: :1888
+    zpages:
+        endpoint: :55679
+
+service:
+    extensions: [pprof, zpages, health_check]
+    pipelines:
+        traces:
+            receivers: [otlp]
+            processors: [batch]
+            exporters:
+                - jaeger
+                - zipkin

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <jenkins.version>2.277.1</jenkins.version>
         <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+        <opentelemetry.version>1.2.0</opentelemetry.version>
     </properties>
     <name>Remoting monitoring with OpenTelemetry</name>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
@@ -33,7 +34,14 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>1.2.0</version>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-bom</artifactId>
+                <version>1.38.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -46,7 +54,12 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk-common</artifactId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>${opentelemetry.version}-alpha</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -54,9 +67,80 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp-metrics</artifactId>
+            <version>${opentelemetry.version}-alpha</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp-trace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-metrics</artifactId>
+            <version>${opentelemetry.version}-alpha</version>
+        </dependency>
+
+        <dependency> <!-- see maskClasses config -->
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <!--
+            Don't bump beyond 20.0 as 21.0 removes com.google.common.util.concurrent.MoreExecutors#sameThreadExecutor()
+            that is used by
+            org.jenkinsci.plugins.workflow.support.concurrent.Futures.addCallback(com.google.common.util.concurrent.ListenableFuture<V>, com.google.common.util.concurrent.FutureCallback<? super V>)
+            See https://github.com/google/guava/wiki/Release21
+            -->
+            <version>20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.15.7</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.perfmark</groupId>
+            <artifactId>perfmark-api</artifactId>
+            <version>0.23.0</version>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <configuration>
+                    <!-- JENKINS-50520: since we need a custom version of Guava -->
+                    <maskClasses>com.google.common.</maskClasses>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <licenses>
         <license>

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/RemotingOpenTelemetryComputerListener.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/RemotingOpenTelemetryComputerListener.java
@@ -1,21 +1,38 @@
 package io.jenkins.plugins.remotingopentelemetry;
 
+import com.google.common.util.concurrent.AbstractCheckedFuture;
+import com.google.protobuf.GeneratedMessageV3;
 import hudson.Extension;
 import hudson.model.Computer;
+import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.ComputerListener;
+import io.grpc.Deadline;
+import io.grpc.MethodDescriptor;
+import io.grpc.internal.ManagedChannelImplBuilder;
+import io.grpc.netty.shaded.io.netty.util.AbstractConstant;
+import io.grpc.protobuf.ProtoUtils;
+import io.grpc.protobuf.lite.ProtoLiteUtils;
+import io.grpc.stub.ClientCalls;
 import io.jenkins.plugins.remotingopentelemetry.commands.SyncMonitoringEngineCommand;
+import io.jenkins.plugins.remotingopentelemetry.engine.EngineConfiguration;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.exporter.otlp.internal.SpanAdapter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.perfmark.PerfMark;
 import jenkins.model.Jenkins.MasterComputer;
 
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Transfers the monitoring engine and the configurations to the online agents
@@ -24,22 +41,49 @@ import java.io.IOException;
  */
 @Extension
 public final class RemotingOpenTelemetryComputerListener extends ComputerListener {
+    final static Logger LOGGER = Logger.getLogger(RemotingOpenTelemetryComputerListener.class.getName());
+
     @Override
     public final void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {
         if (c instanceof MasterComputer) return;
+
         VirtualChannel vc = c.getChannel();
-        vc.call(new SyncMonitoringEngineCommand());
+        if (vc == null) return;
+
+        EngineConfiguration config = RemotingOpenTelemetryConfiguration.get().export();
+        try {
+            vc.call(new SyncMonitoringEngineCommand(config));
+        } catch (IOException | InterruptedException e) {
+            String command = SyncMonitoringEngineCommand.class.getName();
+            Node node = c.getNode();
+            String nodeName = node == null ? "unknown" : node.getNodeName();
+            LOGGER.log(Level.WARNING, "Fail to call " + command + " for " + nodeName , e);
+        }
+
         if (vc instanceof Channel) {
             Channel ch = (Channel) vc;
 
             // Send JAR files to the agent in advance to run the MonitoringEngine even in offline.
             // TODO: Enable to auto-detect the dependent JAR files.
-            ch.preloadJar(getClass().getClassLoader(), OpenTelemetrySdk.class);      // opentelemetry-sdk-<version>.jar
-            ch.preloadJar(getClass().getClassLoader(), CompletableResultCode.class); // opentelemetry-sdk-commmon-<version>.jar
-            ch.preloadJar(getClass().getClassLoader(), SdkTracerProvider.class);     // opentelemetry-sdk-trace-<version>.jar
-            ch.preloadJar(getClass().getClassLoader(), OpenTelemetry.class);         // opentelemetry-api-<version>.jar
-            ch.preloadJar(getClass().getClassLoader(), LoggingSpanExporter.class);   // opentelemetry-exporter-logging-<version>.jar
-            ch.preloadJar(getClass().getClassLoader(), Scope.class);                 // opentelemetry-context-<version>.jar
+            ch.preloadJar(getClass().getClassLoader(), OpenTelemetrySdk.class);          // opentelemetry-sdk
+            ch.preloadJar(getClass().getClassLoader(), CompletableResultCode.class);     // opentelemetry-sdk-commmon
+            ch.preloadJar(getClass().getClassLoader(), SdkTracerProvider.class);         // opentelemetry-sdk-trace
+            ch.preloadJar(getClass().getClassLoader(), OpenTelemetry.class);             // opentelemetry-api
+            ch.preloadJar(getClass().getClassLoader(), LoggingSpanExporter.class);       // opentelemetry-exporter-logging
+            ch.preloadJar(getClass().getClassLoader(), Scope.class);                     // opentelemetry-context
+            ch.preloadJar(getClass().getClassLoader(), OtlpGrpcSpanExporter.class);      // opentelemetry-exporter-otlp-trace
+            ch.preloadJar(getClass().getClassLoader(), SpanAdapter.class);               // opentelemetry-exporter-otlp-common
+            ch.preloadJar(getClass().getClassLoader(), ExportTraceServiceRequest.class); // opentelemetry-proto
+            ch.preloadJar(getClass().getClassLoader(), GeneratedMessageV3.class);        // com.google.protobuf:protobuf-java
+            ch.preloadJar(getClass().getClassLoader(), Deadline.class);                  // io.grpc:grpc-context
+            ch.preloadJar(getClass().getClassLoader(), MethodDescriptor.class);          // io.grpc:grpc-api
+            ch.preloadJar(getClass().getClassLoader(), ProtoUtils.class);                // io.grpc:grpc-protobuf
+            ch.preloadJar(getClass().getClassLoader(), ProtoLiteUtils.class);            // io.grpc:grpc-protobuf-lite
+            ch.preloadJar(getClass().getClassLoader(), ManagedChannelImplBuilder.class); // io.grpc:grpc-core
+            ch.preloadJar(getClass().getClassLoader(), AbstractConstant.class);          // io.grpc:grpc-netty-shaded
+            ch.preloadJar(getClass().getClassLoader(), ClientCalls.class);               // io.grpc:grpc-stub
+            ch.preloadJar(getClass().getClassLoader(), AbstractCheckedFuture.class);     // com.google.guava:guava
+            ch.preloadJar(getClass().getClassLoader(), PerfMark.class);                  // io.perfmark:perfmark-api
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/RemotingOpenTelemetryConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/RemotingOpenTelemetryConfiguration.java
@@ -1,0 +1,76 @@
+package io.jenkins.plugins.remotingopentelemetry;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.model.Computer;
+import hudson.model.Node;
+import hudson.remoting.VirtualChannel;
+import io.jenkins.plugins.remotingopentelemetry.commands.UpdateMonitoringEngineConfigCommand;
+import io.jenkins.plugins.remotingopentelemetry.engine.EngineConfiguration;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.GlobalConfigurationCategory;
+import jenkins.model.Jenkins;
+import jenkins.model.Jenkins.MasterComputer;
+import jenkins.tools.ToolConfigurationCategory;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Configures this plugin
+ */
+@Extension
+public class RemotingOpenTelemetryConfiguration extends GlobalConfiguration {
+
+    private static final Logger LOGGER = Logger.getLogger(RemotingOpenTelemetryConfiguration.class.getName());
+
+    public static RemotingOpenTelemetryConfiguration get() {
+        return ExtensionList.lookupSingleton(RemotingOpenTelemetryConfiguration.class);
+    }
+
+    private String endpoint;
+
+    public RemotingOpenTelemetryConfiguration() {
+        load();
+    }
+
+    @Override
+    @NonNull
+    public ToolConfigurationCategory getCategory() {
+        return GlobalConfigurationCategory.get(ToolConfigurationCategory.class);
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    @DataBoundSetter
+    public void setEndpoint(String endpoint) {
+        if (this.endpoint.equals(endpoint)) return;
+        this.endpoint = endpoint;
+        save();
+        applyConfiguration();
+    }
+
+    public EngineConfiguration export() {
+        return new EngineConfiguration(endpoint);
+    }
+
+    private void applyConfiguration() {
+        for (Node n : Jenkins.get().getNodes()) {
+            Computer c = n.toComputer();
+            if (c == null || c instanceof MasterComputer || c.isOffline()) continue;
+            VirtualChannel ch = c.getChannel();
+            if (ch == null) continue;
+            try {
+                ch.call(new UpdateMonitoringEngineConfigCommand(export()));
+            } catch (InterruptedException | IOException e) {
+                String command = UpdateMonitoringEngineConfigCommand.class.getName();
+                LOGGER.log(Level.WARNING, "Fail to call " + command + " for " + n.getNodeName(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/commands/UpdateMonitoringEngineConfigCommand.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/commands/UpdateMonitoringEngineConfigCommand.java
@@ -4,23 +4,18 @@ import io.jenkins.plugins.remotingopentelemetry.engine.EngineConfiguration;
 import io.jenkins.plugins.remotingopentelemetry.engine.MonitoringEngine;
 import jenkins.security.MasterToSlaveCallable;
 
-/**
- * Synchronizes MonitoringEngine versions and configurations with the controller.
- */
-public final class SyncMonitoringEngineCommand extends MasterToSlaveCallable<Void, InterruptedException> {
+public class UpdateMonitoringEngineConfigCommand extends MasterToSlaveCallable<Void, InterruptedException> {
 
     private final EngineConfiguration config;
 
-    public SyncMonitoringEngineCommand(EngineConfiguration config) {
+    public UpdateMonitoringEngineConfigCommand(EngineConfiguration config) {
         this.config = config;
     }
 
     @Override
     public Void call() throws InterruptedException {
-        // TODO: synchronize the version
-        if (!MonitoringEngine.isRunning()) {
-            MonitoringEngine.launch(config);
-        }
+        MonitoringEngine.terminate();
+        MonitoringEngine.launch(config);
         return null;
     }
 }

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/EngineConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/EngineConfiguration.java
@@ -1,0 +1,22 @@
+package io.jenkins.plugins.remotingopentelemetry.engine;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+
+/**
+ * Immutable configuration object of the Monitoring Engine
+ */
+public class EngineConfiguration implements Serializable {
+
+    @Nonnull
+    private final String endpoint;
+
+    public EngineConfiguration(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    @Nonnull
+    public String getEndpoint() {
+        return endpoint;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/OpenTelemetryProxy.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/OpenTelemetryProxy.java
@@ -2,23 +2,24 @@ package io.jenkins.plugins.remotingopentelemetry.engine;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.SpanProcessor;
 
+/**
+ * Builds and provides OpenTelemetry global object
+ */
 public class OpenTelemetryProxy {
+
     private static final String INSTRUMENTATION_NAME = "jenkins remoting";
+
     private static Tracer tracer;
 
-    public static void build() {
-         build(new LoggingSpanExporter());
-    }
-
-    public static void build(SpanExporter exporter) {
+    public static void build(SpanProcessor processor, Resource resource) {
         SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
-                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .setResource(resource)
+                .addSpanProcessor(processor)
                 .build();
 
         OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/RemotingResourceProvider.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/RemotingResourceProvider.java
@@ -1,0 +1,21 @@
+package io.jenkins.plugins.remotingopentelemetry.engine;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+
+/**
+ * Provides {@link Resource}
+ */
+public class RemotingResourceProvider {
+    /**
+     * @return configured {@link Resource}
+     */
+    public static Resource create() {
+        // TODO: more attributes,
+        // TODO: enable to configure them
+        return Resource.create(Attributes.of(
+                ResourceAttributes.SERVICE_NAME, "Jenkins Agent"
+        ));
+    }
+}

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/RemotingSpanExporterProvider.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/RemotingSpanExporterProvider.java
@@ -1,0 +1,23 @@
+package io.jenkins.plugins.remotingopentelemetry.engine;
+
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Provides {@link SpanExporter}
+ */
+public class RemotingSpanExporterProvider {
+    /**
+     * @param config to create {@link SpanExporter}
+     * @return configured {@link SpanExporter}
+     */
+    @Nonnull
+    public static SpanExporter create(EngineConfiguration config) {
+        // TODO: Enable to configure timeout
+        return OtlpGrpcSpanExporter.builder()
+                .setEndpoint(config.getEndpoint())
+                .build();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RootListener.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RootListener.java
@@ -11,11 +11,15 @@ import java.util.EventListener;
  * Handles the events from {@link MonitoringEngine} and setups child event listeners.
  */
 public class RootListener implements EventListener {
+
     private final RemoteEngineListener remoteEngineListener = new RemoteEngineListener();
 
     @Nullable
     private Engine remoteEngine = null;
 
+    /**
+     * Invoked before running the MonitoringEngine thread
+     */
     public void preStartMonitoringEngine() {
         remoteEngine = Engine.current();
         if (remoteEngine != null) {
@@ -27,13 +31,18 @@ public class RootListener implements EventListener {
         }
     }
 
+    /**
+     * Invoked when terminating the MonitoringEngine thread
+     */
     public void onTerminateMonitoringEngine() {
         onTerminateMonitoringEngine(null);
     }
+
     public void onTerminateMonitoringEngine(Exception e) {
         if (remoteEngine != null) {
             remoteEngine.removeListener(remoteEngineListener);
         }
+
         ChannelKeepAliveSpan channelKeepAliveSpan = ChannelKeepAliveSpan.current();
         if (channelKeepAliveSpan != null) {
             channelKeepAliveSpan.end();

--- a/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/span/ChannelKeepAliveSpan.java
+++ b/src/main/java/io/jenkins/plugins/remotingopentelemetry/engine/span/ChannelKeepAliveSpan.java
@@ -4,21 +4,29 @@ import io.jenkins.plugins.remotingopentelemetry.engine.OpenTelemetryProxy;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class ChannelKeepAliveSpan implements MonitoringSpan {
+
     @Nullable
     private static ChannelKeepAliveSpan currentSpan = null;
-    public static final String SPAN_NAME = "channel keep alive";
+
+    public static final String SPAN_NAME = "Channel Keep-Alive";
+
     @Nullable
     public static synchronized ChannelKeepAliveSpan current() {
         return currentSpan;
     }
+
     private static synchronized void setCurrent(ChannelKeepAliveSpan span) {
         currentSpan = span;
     }
 
+    @Nonnull
     private final Tracer tracer;
+
+    @Nullable
     private Span span;
 
     public ChannelKeepAliveSpan() {
@@ -26,7 +34,7 @@ public class ChannelKeepAliveSpan implements MonitoringSpan {
     }
 
     public void start() {
-        this.span = tracer.spanBuilder(SPAN_NAME).startSpan();
+        span = tracer.spanBuilder(SPAN_NAME).startSpan();
         if (currentSpan != null) {
             currentSpan.end();
         }

--- a/src/main/resources/io/jenkins/plugins/remotingopentelemetry/RemotingOpenTelemetryConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/remotingopentelemetry/RemotingOpenTelemetryConfiguration/config.jelly
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:section title="${%Remoting OpenTelemetry Plugin}">
+        <f:entry field="endpoint" title="${%Endpoint}">
+            <f:textbox/>
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/src/test/java/io/jenkins/plugins/remotingopentelemetry/commands/SyncMonitoringEngineCommandTest.java
+++ b/src/test/java/io/jenkins/plugins/remotingopentelemetry/commands/SyncMonitoringEngineCommandTest.java
@@ -1,0 +1,19 @@
+package io.jenkins.plugins.remotingopentelemetry.commands;
+
+import hudson.slaves.DumbSlave;
+import io.jenkins.plugins.remotingopentelemetry.engine.EngineConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class SyncMonitoringEngineCommandTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void test() throws Exception {
+        DumbSlave n = j.createOnlineSlave();
+        EngineConfiguration config = new EngineConfiguration("http://localhost");
+        n.getChannel().call(new SyncMonitoringEngineCommand(config));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/remotingopentelemetry/commands/UpdateMonitoringEngineConfigCommandTest.java
+++ b/src/test/java/io/jenkins/plugins/remotingopentelemetry/commands/UpdateMonitoringEngineConfigCommandTest.java
@@ -1,0 +1,19 @@
+package io.jenkins.plugins.remotingopentelemetry.commands;
+
+import hudson.slaves.DumbSlave;
+import io.jenkins.plugins.remotingopentelemetry.engine.EngineConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class UpdateMonitoringEngineConfigCommandTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void test() throws Exception {
+        DumbSlave n = j.createOnlineSlave();
+        EngineConfiguration config = new EngineConfiguration("http://localhost");
+        n.getChannel().call(new UpdateMonitoringEngineConfigCommand(config));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/MonitoringEngineTest.java
+++ b/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/MonitoringEngineTest.java
@@ -9,18 +9,20 @@ import java.util.stream.Stream;
 public class MonitoringEngineTest {
     @Test
     public void testIsRunning() throws Exception {
-        MonitoringEngine.launch();
+        EngineConfiguration config = new EngineConfiguration("http://localhost");
+        MonitoringEngine.launch(config);
         assert MonitoringEngine.isRunning();
         MonitoringEngine.terminate();
         assert !MonitoringEngine.isRunning();
-        MonitoringEngine.launch();
+        MonitoringEngine.launch(config);
         assert MonitoringEngine.isRunning();
     }
 
     @Test
     public void testOnlyOneMonitoringThread() throws Exception {
-        MonitoringEngine.launch();
-        MonitoringEngine.launch();
+        EngineConfiguration config = new EngineConfiguration("http://localhost");
+        MonitoringEngine.launch(config);
+        MonitoringEngine.launch(config);
         ThreadGroup currentThreadGroup = Thread.currentThread().getThreadGroup();
         Thread[] siblingThreads = new Thread[currentThreadGroup.activeCount()];
         currentThreadGroup.enumerate(siblingThreads);

--- a/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RemoteEngineListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RemoteEngineListenerTest.java
@@ -1,8 +1,11 @@
 package io.jenkins.plugins.remotingopentelemetry.engine.listener;
 
 import io.jenkins.plugins.remotingopentelemetry.engine.OpenTelemetryProxy;
+import io.jenkins.plugins.remotingopentelemetry.engine.RemotingResourceProvider;
 import io.jenkins.plugins.remotingopentelemetry.engine.span.ChannelKeepAliveSpan;
+import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,7 +16,8 @@ public class RemoteEngineListenerTest {
     @Before
     public void setup() throws Exception {
         exporter = InMemorySpanExporter.create();
-        OpenTelemetryProxy.build(exporter);
+        Resource resource = RemotingResourceProvider.create();
+        OpenTelemetryProxy.build(SimpleSpanProcessor.create(exporter), resource);
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RootListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/listener/RootListenerTest.java
@@ -1,8 +1,11 @@
 package io.jenkins.plugins.remotingopentelemetry.engine.listener;
 
 import io.jenkins.plugins.remotingopentelemetry.engine.OpenTelemetryProxy;
+import io.jenkins.plugins.remotingopentelemetry.engine.RemotingResourceProvider;
 import io.jenkins.plugins.remotingopentelemetry.engine.span.ChannelKeepAliveSpan;
+import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,7 +16,8 @@ public class RootListenerTest {
     @Before
     public void setup() throws Exception {
         InMemorySpanExporter exporter = InMemorySpanExporter.create();
-        OpenTelemetryProxy.build(exporter);
+        Resource resource = RemotingResourceProvider.create();
+        OpenTelemetryProxy.build(SimpleSpanProcessor.create(exporter), resource);
         rootListener = new RootListener();
     }
 

--- a/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/span/ChannelKeepAliveSpanTest.java
+++ b/src/test/java/io/jenkins/plugins/remotingopentelemetry/engine/span/ChannelKeepAliveSpanTest.java
@@ -1,20 +1,21 @@
 package io.jenkins.plugins.remotingopentelemetry.engine.span;
 
 import io.jenkins.plugins.remotingopentelemetry.engine.OpenTelemetryProxy;
+import io.jenkins.plugins.remotingopentelemetry.engine.RemotingResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class ChannelKeepAliveSpanTest {
+    InMemorySpanExporter exporter;
     @Before
     public void setup() throws Exception {
-        InMemorySpanExporter exporter = InMemorySpanExporter.create();
-        OpenTelemetryProxy.build(exporter);
-        ChannelKeepAliveSpan span = ChannelKeepAliveSpan.current();
-        if (span != null) {
-            span.end();
-        }
+        exporter = InMemorySpanExporter.create();
+        Resource resource = RemotingResourceProvider.create();
+        OpenTelemetryProxy.build(SimpleSpanProcessor.create(exporter), resource);
     }
 
     @Test
@@ -22,19 +23,26 @@ public class ChannelKeepAliveSpanTest {
         assert ChannelKeepAliveSpan.current() == null;
         new ChannelKeepAliveSpan().start();
         assert ChannelKeepAliveSpan.current() != null;
-        new ChannelKeepAliveSpan().end();
+        ChannelKeepAliveSpan.current().end();
     }
 
     @Test
     public void testEnd() throws Exception {
         new ChannelKeepAliveSpan().start();
         assert ChannelKeepAliveSpan.current() != null;
-        new ChannelKeepAliveSpan().end();
+        ChannelKeepAliveSpan.current().end();
         assert ChannelKeepAliveSpan.current() == null;
+        assert exporter.getFinishedSpanItems().size() == 1;
+        assert exporter.getFinishedSpanItems().get(0).getName().equals("Channel Keep-Alive");
     }
 
     @After
     public void tearDown() throws Exception {
         OpenTelemetryProxy.clean();
+        exporter.reset();
+        ChannelKeepAliveSpan span = ChannelKeepAliveSpan.current();
+        if (span != null) {
+            span.end();
+        }
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

close #10 (Enable to propagate configuration)
close #12 (Enable to provide collected telemetry data to the OpenTelemetry collector)

ref #26 (Quick demo)

## What I did

- Enable to configure the OpenTelemetry collector endpoint used on the agent side.
  - on the Global Tool Configuration page
  - other configuration options are to be determined (see also leaving issues).
- Enable to provide telemetry data to the OpenTelemetry collector.
  - Using the configured endpoint.
  - Currently, Channel Keep-Alive span only.
- Tracer demo example using OpenTelemetry collector / Jaeger / Zipkin
  - Using docker-compose to launch OpenTelmetry collector / Jaeger / Zipkin
  - Details are in example/README.adoc

### Jaeger example

![Screen Shot 2021-06-17 at 13 07 21](https://user-images.githubusercontent.com/44729662/122329795-f9d78200-cf6c-11eb-8595-343c3a7b5534.png)

### Zipkin example

![Screen Shot 2021-06-17 at 13 08 18](https://user-images.githubusercontent.com/44729662/122329870-1b386e00-cf6d-11eb-9d32-e5fe7675820b.png)

## Leaving Issues

#38 #39 

## Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] All follow-ups are documented as issues and-or TODO comments
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
- [x] Please update user documentation if needed
- [x] Please update developer documentation if needed

<!--
Put an `x` into the [ ] to show you have filled the information
-->
