### PR TITLE
Fixes SCM URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         </license>
     </licenses>
 
-    <scm>
+    <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
         <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>


### PR DESCRIPTION
Because the source code of the plugin lives in a module of the repository, when it is released, its URL points to the `${parent.scm.url}/<module-name>`. However, this URL is not valid (404). 

Adding those tag attribute, the modules SCM URL will be identical to the parent URL (this repository). 
That URL is used by the update-center to link the plugin details with the GitHub repository and is used in plugins.jenkins.io/remoting-opentelemetry page. 

This changes make sure the URL is correct and the link is pointing to the plugin repository and not a 404.

<!-- Please describe your pull request here. -->

## Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] All follow-ups are documented as issues and-or TODO comments
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
- [ ] Please update user documentation if needed
- [ ] Please update developer documentation if needed

<!--
Put an `x` into the [ ] to show you have filled the information
-->
